### PR TITLE
Fix playback stopping after each track

### DIFF
--- a/lib/mediakit_player.dart
+++ b/lib/mediakit_player.dart
@@ -60,9 +60,10 @@ class MediaKitPlayer extends AudioPlayerPlatform {
         _dataController.add(PlayerDataMessage(volume: volume / 100.0));
       }),
       _player.stream.completed.listen((completed) {
-        _processingState = completed
-            ? ProcessingStateMessage.completed
-            : ProcessingStateMessage.ready;
+        // _processingState = completed
+        //     ? ProcessingStateMessage.completed
+        //     : ProcessingStateMessage.ready;
+        _processingState = ProcessingStateMessage.ready;
         _updatePlaybackEvent();
       }),
       _player.stream.error.listen((error) {


### PR DESCRIPTION
So I've managed to fix the issue described in #3 by never returning `ProcessingStateMessage.completed`. That probably breaks stopping, but that's not as much of a problem in our case.  
I haven't had time to look into in properly, but I'm guessing the check for when `ProcessingStateMessage.completed` should be returned instead of `ProcessingStateMessage.ready` isn't quiet correct, so I'm opening this draft PR to see if you might have an idea where to look for a proper fix?