### PR TITLE
Add `libmpv` parameter to `ensureInitialized` 

### DIFF
--- a/lib/just_audio_media_kit.dart
+++ b/lib/just_audio_media_kit.dart
@@ -12,6 +12,8 @@ import 'package:universal_platform/universal_platform.dart';
 class JustAudioMediaKit extends JustAudioPlatform {
   JustAudioMediaKit();
 
+  static String? _libmpv;
+
   /// The internal MPV player's logLevel
   static MPVLogLevel mpvLogLevel = MPVLogLevel.error;
 
@@ -48,7 +50,10 @@ class JustAudioMediaKit extends JustAudioPlatform {
     bool android = false,
     bool iOS = false,
     bool macOS = false,
+    String? libmpv,
   }) {
+    _libmpv = libmpv;
+
     if ((UniversalPlatform.isLinux && linux) ||
         (UniversalPlatform.isWindows && windows) ||
         (UniversalPlatform.isAndroid && android) ||
@@ -65,7 +70,7 @@ class JustAudioMediaKit extends JustAudioPlatform {
 
   @override
   Future<AudioPlayerPlatform> init(InitRequest request) async {
-    MediaKit.ensureInitialized();
+    MediaKit.ensureInitialized(libmpv: _libmpv);
 
     if (_players.containsKey(request.id)) {
       throw PlatformException(

--- a/lib/just_audio_media_kit.dart
+++ b/lib/just_audio_media_kit.dart
@@ -12,6 +12,8 @@ import 'package:universal_platform/universal_platform.dart';
 class JustAudioMediaKit extends JustAudioPlatform {
   JustAudioMediaKit();
 
+  /// The path to the libmpv dynamic library.
+  /// The name of the library is generally `libmpv.so` on GNU/Linux and `libmpv-2.dll` on Windows.
   static String? _libmpv;
 
   /// The internal MPV player's logLevel


### PR DESCRIPTION
Hi, thank you for making this library, I've been using it for a while now. However, there's a problem with the `media_kit` library on Windows which leads to a delay between tracks. I just found a way to fix it by using the latest version of `libmpv` (maybe because it was using old `libmpv`). This leads to this PR, I added `libmpv` parameter to the `ensureInitialized` method for both JustAudioMediaKit and MediaKit so users can set the path to libmpv dynamic library by themselves (if they need to).