### PR TITLE
fix: invalid range error while playing

### DIFF
--- a/lib/just_audio_media_kit.dart
+++ b/lib/just_audio_media_kit.dart
@@ -87,8 +87,7 @@ class JustAudioMediaKit extends JustAudioPlatform {
   @override
   Future<AudioPlayerPlatform> init(InitRequest request) async {
     if (_players.containsKey(request.id)) {
-      throw PlatformException(
-          code: 'error', message: 'Player ${request.id} already exists!');
+      return _players[request.id]!;
     }
 
     _logger.fine('instantiating new player ${request.id}');

--- a/lib/mediakit_player.dart
+++ b/lib/mediakit_player.dart
@@ -35,8 +35,11 @@ class MediaKitPlayer extends AudioPlayerPlatform {
   /// [LoadRequest.initialPosition] or [seek] request before [Player.play] was called and/or finished loading.
   Duration? _setPosition;
 
-  Media get _currentMedia =>
-      _player.state.playlist.medias[_player.state.playlist.index];
+  Media? get _currentMedia {
+    // no media is currently playing and playlist is empty.
+    if (_player.state.playlist.medias.isEmpty) return null;
+    return _player.state.playlist.medias[_player.state.playlist.index];
+  }
 
   MediaKitPlayer(super.id) {
     _player = Player(
@@ -57,7 +60,8 @@ class MediaKitPlayer extends AudioPlayerPlatform {
 
     _streamSubscriptions = [
       _player.stream.duration.listen((duration) {
-        if (_currentMedia.extras?['overrideDuration'] != null) return;
+        if (_currentMedia == null) return;
+        if (_currentMedia!.extras?['overrideDuration'] != null) return;
 
         _processingState = ProcessingStateMessage.ready;
         if (_setPosition != null && duration.inSeconds > 0) {
@@ -111,7 +115,7 @@ class MediaKitPlayer extends AudioPlayerPlatform {
           _currentIndex = playlist.index;
         }
         _updatePlaybackEvent(
-            duration: _currentMedia.extras?['overrideDuration']);
+            duration: _currentMedia?.extras?['overrideDuration']);
       }),
       _player.stream.playlistMode.listen((playlistMode) {
         _dataController.add(


### PR DESCRIPTION
While playing audio initially there is no media in playlist and throws invalid range error. This PR fixes the issue.