### PR TITLE
feat: expose volume-max and audio-filters as static config

### DIFF
--- a/lib/just_audio_media_kit.dart
+++ b/lib/just_audio_media_kit.dart
@@ -48,6 +48,25 @@ class JustAudioMediaKit extends JustAudioPlatform {
   /// [the related issue](https://github.com/Pato05/just_audio_media_kit/issues/11) for more information
   static bool prefetchPlaylist = false;
 
+  /// Maximum mpv `volume` value, expressed as a multiplier (1.0 = 100% =
+  /// mpv default; 1.3 = 130% = mpv's own default cap; 2.0 = 200% =
+  /// typical "boost" target). Set BEFORE [ensureInitialized]. Applied to
+  /// every player created after the assignment via the [Player]
+  /// constructor's `setProperty('volume-max', ...)` call.
+  ///
+  /// Default 1.3 matches mpv's documented default so unmodified
+  /// consumers see no behavior change.
+  static double volumeMax = 1.3;
+
+  /// Optional mpv `audio-filters` chain applied to every player at
+  /// construction time. Format: see mpv's audio-filters docs (lavfi
+  /// passthrough is common, e.g. `'lavfi=[acompressor=...]'`).
+  ///
+  /// Set BEFORE [ensureInitialized] to apply at startup, OR call
+  /// [setMpvProperty]`('audio-filters', filters)` at runtime to swap
+  /// on an existing player. Null leaves the default chain (no filters).
+  static String? audioFilters;
+
   static final _logger = Logger('JustAudioMediaKit');
   final _players = HashMap<String, MediaKitPlayer>();
 
@@ -82,6 +101,32 @@ class JustAudioMediaKit extends JustAudioPlatform {
   /// Registers the plugin with [JustAudioPlatform]
   static void registerWith() {
     JustAudioPlatform.instance = JustAudioMediaKit._();
+  }
+
+  /// Set an mpv property on every active [MediaKitPlayer]. Useful for
+  /// runtime swaps of properties like `audio-filters` that are not in the
+  /// static config block (or that need to change after init).
+  ///
+  /// Iterates the internal player map and calls each player's
+  /// [MediaKitPlayer.setMpvProperty]. No-op if no players are active or if
+  /// [JustAudioPlatform.instance] has not been registered as
+  /// [JustAudioMediaKit] (e.g., in a unit test environment without a
+  /// platform init).
+  ///
+  /// `just_audio.AudioPlayer._id` is private with no public getter,
+  /// which is why this is an iteration over all players rather than a
+  /// per-player lookup by ID. For single-player consumers (the typical
+  /// case), this is correct. For multi-player consumers, it applies the
+  /// same property to every player — which is the right semantic for
+  /// `audio-filters` (the chain applies to whatever player is rendering)
+  /// and for `volume-max` (a per-player ceiling that should usually be
+  /// uniform across an app).
+  static Future<void> setMpvProperty(String key, dynamic value) async {
+    final instance = JustAudioPlatform.instance;
+    if (instance is! JustAudioMediaKit) return;
+    for (final player in instance._players.values) {
+      await player.setMpvProperty(key, value);
+    }
   }
 
   @override

--- a/lib/src/mediakit_player.dart
+++ b/lib/src/mediakit_player.dart
@@ -63,6 +63,18 @@ class MediaKitPlayer extends AudioPlayerPlatform {
       setProperty(_player, 'prefetch-playlist', 'yes');
     }
 
+    // Volume Boost v2 — apply static config to mpv. Like the
+    // prefetch-playlist call above, these are not awaited; mpv applies
+    // them opportunistically as it processes the property queue.
+    setProperty(
+      _player,
+      'volume-max',
+      (JustAudioMediaKit.volumeMax * 100).toString(),
+    );
+    if (JustAudioMediaKit.audioFilters != null) {
+      setProperty(_player, 'audio-filters', JustAudioMediaKit.audioFilters!);
+    }
+
     _streamSubscriptions = [
       _player.stream.duration.listen((duration) {
         if (_currentMedia?.extras?['overrideDuration'] != null) return;
@@ -284,6 +296,14 @@ class MediaKitPlayer extends AudioPlayerPlatform {
     return _player
         .setVolume(request.volume * 100.0)
         .then((value) => SetVolumeResponse());
+  }
+
+  /// Set an arbitrary mpv property on the underlying [Player] at runtime.
+  /// Useful for properties not in the static [JustAudioMediaKit] config
+  /// block. Delegates to the internal [setProperty] helper used by
+  /// `prefetch-playlist` and `volume-max`.
+  Future<void> setMpvProperty(String key, dynamic value) async {
+    await setProperty(_player, key, value);
   }
 
   @override


### PR DESCRIPTION
## Summary
- Adds `JustAudioMediaKit.volumeMax` (default 1.3 = mpv's own default) and `JustAudioMediaKit.audioFilters` (default null) static config fields, applied via `setProperty` in `MediaKitPlayer`'s constructor.
- Adds a public runtime helper for setting arbitrary mpv properties on existing players: `JustAudioMediaKit.setMpvProperty(key, value)` (static, iterates all players) and `MediaKitPlayer.setMpvProperty(key, value)` (instance).

## Motivation
Downstream apps wanting to amplify volume above mpv's 130% default cap currently have no public knob to lift `volume-max`. The internal `setProperty` helper in `lib/src/set_property_io.dart` exists but isn't exposed via the public API. This PR surfaces it minimally.

Use case: an audiobook player that lets the user boost volume on quiet content to 200%, with a runtime-toggleable `acompressor` filter via `audio-filters` for soft-limiting on transient peaks.

## Compatibility
- Defaults preserve existing behavior (volumeMax=1.3 = mpv default; audioFilters=null = no filter).
- No interface breakage. New methods are additive.
- No new dependencies.

## Test plan
- [ ] Existing tests pass (none in repo currently — analyze is clean for lib/)
- [ ] Manual: set JustAudioMediaKit.volumeMax = 2.0, verify Player.state.volume reaches 200 when setVolume(2.0) called from just_audio.AudioPlayer
- [ ] Manual: set audioFilters = 'lavfi=[acompressor=threshold=0.7:ratio=4]', verify mpv applies the filter (audible compression on loud content)